### PR TITLE
Update Readme for go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the home for all things that combine [Buffalo](https://github.com/gobuff
 ## Installation
 
 ```bash
-$ go get -u -v github.com/gobuffalo/buffalo-pop
+$ go get -u -v github.com/gobuffalo/buffalo-pop/...
 ```
 
 ## Transaction Middleware


### PR DESCRIPTION
With the previous command I was getting the following error:  `package github.com/gobuffalo/buffalo-pop: no Go files in ...`