### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAGS ?= "sqlite"
 GO_BIN ?= go
 
-install:
+install: deps
 	packr
 	$(GO_BIN) install -tags ${TAGS} -v ./.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO_BIN ?= go
 
 install:
 	packr
-	$(GO_BIN) install -v ./.
+	$(GO_BIN) install -tags ${TAGS} -v ./.
 
 deps:
 	$(GO_BIN) get github.com/gobuffalo/release


### PR DESCRIPTION
Running `make install` didn't use tags whereas the others do.

It's still possible to build/install without sqlite support by running `TAGS= make install`.

Please note:
I couldn't really find information on how buffalo and especially buffalo-pop are being released. Therefore, I'm not really sure if this pr is braking it's release mechanism or not.
If it is, please guide me to some more information on this so I can try to fix it properly.