### PR TITLE
applied txlogger to log transaction information

### DIFF
--- a/pop/logger.go
+++ b/pop/logger.go
@@ -39,3 +39,50 @@ func Logger(app *buffalo.App) logger {
 		}
 	}
 }
+
+// since Pop v6.1.0
+type txlogger = func(level logging.Level, conn interface{}, s string, args ...interface{})
+
+func TxLogger(app *buffalo.App) txlogger {
+	return func(lvl logging.Level, conn interface{}, s string, args ...interface{}) {
+		if !pop.Debug && lvl <= logging.Debug {
+			return
+		}
+
+		l := app.Logger
+
+		if pop.Color {
+			s = color.YellowString(s)
+		}
+
+		switch typed := conn.(type) {
+		case *pop.Connection:
+			l = l.WithField("conn", typed.ID)
+			if typed.TX != nil {
+				l = l.WithField("tx", typed.TX.ID)
+			}
+		case *pop.Tx:
+			l = l.WithField("tx", typed.ID)
+		default:
+			l = l.WithField("conn", "unknown")
+		}
+
+		switch lvl {
+		case logging.SQL:
+			if len(args) > 0 {
+				for i, a := range args {
+					l = l.WithField(fmt.Sprintf("$%d", i+1), a)
+				}
+			}
+			l.Debug(s)
+		case logging.Debug:
+			l.Debugf(s, args...)
+		case logging.Info:
+			l.Infof(s, args...)
+		case logging.Warn:
+			l.Warnf(s, args...)
+		default:
+			l.Printf(s, args...)
+		}
+	}
+}


### PR DESCRIPTION
### What is being done in this PR?

- Applied `txlogger` that was introduced in Pop v6.1.0 to log transaction information on the log.
- only check 4xx or greater when checking handler errors. (very rare but status 1xx is actually not an error)

Ready to be [v3.0.7](https://github.com/gobuffalo/buffalo-pop/milestone/2?closed=1)